### PR TITLE
Improve garden-bot frontend: next-watering tile, water status, temp color coding

### DIFF
--- a/garden-bot/front-end/index.html
+++ b/garden-bot/front-end/index.html
@@ -44,7 +44,6 @@
           </div>
           <div class="device-picker" id="device-picker">
             <div class="device-toggle" id="device-toggle">
-              <span class="device-dot"></span>
               <span id="device-label">cherry-3-pot</span>
               <span class="device-caret">&#9662;</span>
             </div>

--- a/garden-bot/front-end/index.html
+++ b/garden-bot/front-end/index.html
@@ -49,8 +49,8 @@
               <span class="device-caret">&#9662;</span>
             </div>
             <div class="device-menu" id="device-menu" hidden>
-              <div class="device-option" data-device="cherry-3-pot"><span class="device-option-dot"></span>cherry-3-pot</div>
-              <div class="device-option" data-device="cherry-2-pot"><span class="device-option-dot"></span>cherry-2-pot</div>
+              <div class="device-option" data-device="cherry-3-pot">cherry-3-pot</div>
+              <div class="device-option" data-device="cherry-2-pot">cherry-2-pot</div>
             </div>
           </div>
         </div>
@@ -91,18 +91,15 @@
             <div class="info-label">last watered</div>
             <div class="info-value" id="last-watered-time">&ndash;</div>
           </div>
-          <div class="info-box info-box--tank">
-            <div class="info-label">tank</div>
-            <div class="info-tank">
-              <span class="tank-dot" id="tank-dot"></span>
-              <span class="info-value" id="tank-label">&ndash;</span>
-            </div>
+          <div class="info-box">
+            <div class="info-label">next watering</div>
+            <div class="info-value" id="next-watering-time">&ndash;</div>
           </div>
         </div>
 
         <div class="chart-header">
-          <span class="chart-title">moisture &middot; temp &middot; battery</span>
-          <span class="chart-max-temp" id="max-temperature">max &ndash;&deg;C</span>
+          <span class="chart-title">water: <span class="water-status-word" id="water-status-word">&ndash;</span></span>
+          <span class="chart-max-temp"><span class="chart-max-temp-label">MAX</span> <span id="max-temperature">&ndash;&deg;C</span></span>
         </div>
         <div id="chart"></div>
         <div class="legend">

--- a/garden-bot/front-end/index.js
+++ b/garden-bot/front-end/index.js
@@ -16,6 +16,53 @@ const THEME = {
   tipText: '#eaf3df'
 };
 
+// Temperature brackets, coldest to hottest, mirroring the watering-frequency
+// brackets in the firmware (calculateSecondsBetweenWateringFromMaxRecentTemperature).
+const TEMP_BRACKETS = [
+  { min: -Infinity, color: '#5fb0e6' }, // < 10, cold blue
+  { min: 10, color: '#5fd2c0' },
+  { min: 15, color: '#a8c686' },
+  { min: 19, color: '#e6c65f' },
+  { min: 25, color: '#f4a45e' },
+  { min: 29, color: '#e0524a' } // hot red
+];
+
+function tempColor(tempC) {
+  let color = TEMP_BRACKETS[0].color;
+  for (const bracket of TEMP_BRACKETS) {
+    if (tempC >= bracket.min) color = bracket.color;
+  }
+  return color;
+}
+
+// Mirrors firmware's calculateSecondsBetweenWateringFromMaxRecentTemperature().
+function secondsBetweenWateringFromMaxRecentTemperature(maxRecentTemperature) {
+  if (maxRecentTemperature >= 29) return 3600 * 6;
+  if (maxRecentTemperature >= 25) return 3600 * 15;
+  if (maxRecentTemperature >= 19) return 3600 * 24 * 2;
+  if (maxRecentTemperature >= 15) return 3600 * 24 * 3;
+  if (maxRecentTemperature >= 10) return 3600 * 24 * 4;
+  return 3600 * 24 * 5;
+}
+
+// Next local occurrence of `hour:00` at or after `fromMs`.
+function nextOccurrenceOfHour(fromMs, hour) {
+  const d = new Date(fromMs);
+  d.setHours(hour, 0, 0, 0);
+  if (d.getTime() < fromMs) d.setDate(d.getDate() + 1);
+  return d.getTime();
+}
+
+// Mirrors firmware's shouldWater(): watering happens at 8:00, or at 15:00 if
+// the max recent temperature was hot enough, once enough time has passed
+// since the last watering for the current max recent temperature bracket.
+function computeNextWatering(lastWateredMs, maxRecentTemperature) {
+  const earliestMs = lastWateredMs + secondsBetweenWateringFromMaxRecentTemperature(maxRecentTemperature) * 1000;
+  const candidates = [nextOccurrenceOfHour(earliestMs, 8)];
+  if (maxRecentTemperature >= 29) candidates.push(nextOccurrenceOfHour(earliestMs, 15));
+  return Math.min(...candidates);
+}
+
 const state = {
   days: 3,
   device: 'cherry-3-pot',
@@ -78,7 +125,7 @@ function toPoints(dataObj) {
   return points;
 }
 
-const DELAYED_AFTER_MS = 2 * 60 * 60 * 1000;
+const DELAYED_AFTER_MS = 35 * 60 * 1000;
 const OFFLINE_AFTER_MS = 6 * 60 * 60 * 1000;
 
 // Device publishes roughly every PUBLISH_INTERVAL_MS (matches firmware's
@@ -110,7 +157,10 @@ function getLiveStatus(lastUpdateMs) {
 function computeStats(points) {
   const last = points[points.length - 1];
   const wateredEvents = points.filter(p => p.watered);
-  const lastWatered = wateredEvents.length ? wateredEvents[wateredEvents.length - 1].t : null;
+  const lastWateredMs = wateredEvents.length ? wateredEvents[wateredEvents.length - 1].t : null;
+  const recentPoints = lastWateredMs ? points.filter(p => p.t > lastWateredMs) : points;
+  const maxRecentTemp = recentPoints.length ? Math.max(...recentPoints.map(p => p.temp)) : last.temp;
+  const maxTemp = Math.max(...points.map(p => p.temp));
   return {
     curMoisture: last.moisture,
     curBattery: last.battery,
@@ -120,8 +170,10 @@ function computeStats(points) {
     waterColor: last.water ? '#7fd49b' : '#e08a5e',
     lastUpdateMs: last.t,
     lastUpdate: fmt(last.t),
-    lastWatered: lastWatered ? fmt(lastWatered) : '—',
-    maxTemp: Math.max(...points.map(p => p.temp))
+    lastWatered: lastWateredMs ? fmt(lastWateredMs) : '—',
+    nextWatering: lastWateredMs ? fmt(computeNextWatering(lastWateredMs, maxRecentTemp)) : '—',
+    maxTemp,
+    maxTempColor: tempColor(maxTemp)
   };
 }
 
@@ -142,9 +194,15 @@ function renderStats(points) {
 
   document.getElementById('last-updated-time').textContent = s.lastUpdate;
   document.getElementById('last-watered-time').textContent = s.lastWatered;
-  document.getElementById('tank-label').textContent = s.waterLabel;
-  document.getElementById('tank-dot').style.background = s.waterColor;
-  document.getElementById('max-temperature').textContent = 'max ' + s.maxTemp + '°C';
+  document.getElementById('next-watering-time').textContent = s.nextWatering;
+
+  const waterStatusWord = document.getElementById('water-status-word');
+  waterStatusWord.textContent = s.waterLabel;
+  waterStatusWord.style.color = s.waterColor;
+
+  const maxTemperatureEl = document.getElementById('max-temperature');
+  maxTemperatureEl.textContent = s.maxTemp + '°C';
+  maxTemperatureEl.style.color = s.maxTempColor;
 
   const live = getLiveStatus(s.lastUpdateMs);
   const liveBadge = document.getElementById('live-badge');

--- a/garden-bot/front-end/style.css
+++ b/garden-bot/front-end/style.css
@@ -209,7 +209,7 @@ body {
 
 .device-caret {
   color: #7fb39a;
-  font-size: 11px;
+  font-size: 15px;
 }
 
 .device-menu {
@@ -238,19 +238,6 @@ body {
 .device-option.active {
   color: #eff6e4;
   background: rgba(168, 198, 134, .12);
-}
-
-.device-option-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  margin-right: 8px;
-  background: rgba(168, 198, 134, .4);
-}
-
-.device-option.active .device-option-dot {
-  background: #e8d87a;
 }
 
 .gauges {
@@ -339,13 +326,6 @@ body {
   background: rgba(0, 0, 0, .18);
 }
 
-.info-box--tank {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
 .info-label {
   font: 400 9px 'Space Mono', monospace;
   letter-spacing: .08em;
@@ -357,20 +337,6 @@ body {
   font: 600 14px 'Hanken Grotesk', sans-serif;
   color: #e6f0d9;
   margin-top: 3px;
-}
-
-.info-tank {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  margin-top: 3px;
-}
-
-.tank-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #e6f0d9;
 }
 
 .chart-header {
@@ -392,9 +358,17 @@ body {
   margin: 18px 0 2px;
 }
 
+.water-status-word {
+  font-weight: 700;
+}
+
 .chart-max-temp {
   font: 400 10px 'Space Mono', monospace;
   color: #f4a45e;
+}
+
+.chart-max-temp-label {
+  letter-spacing: .1em;
 }
 
 #chart {

--- a/garden-bot/front-end/style.css
+++ b/garden-bot/front-end/style.css
@@ -199,17 +199,9 @@ body {
   color: #cfe3b6;
 }
 
-.device-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  background: #e8d87a;
-  flex-shrink: 0;
-}
-
 .device-caret {
   color: #7fb39a;
-  font-size: 15px;
+  font-size: 18px;
 }
 
 .device-menu {


### PR DESCRIPTION
Replace the tank tile with a next-watering estimate that mirrors the firmware's
watering schedule (last watered time, max recent temperature, watering window).
Show water availability as colored text above the chart instead of duplicating
the chart legend, capitalize MAX, and color the max temperature by the same
temperature brackets the firmware uses for watering frequency (cold blue to hot
red). Shorten the delayed threshold to 35 minutes. Remove the device dropdown's
yellow selection dot (it clashed with the delayed-status color) and enlarge the
dropdown caret.