### PR TITLE
Persist day range/device selection and allow manual refresh via live badge

### DIFF
--- a/garden-bot/front-end/index.html
+++ b/garden-bot/front-end/index.html
@@ -34,6 +34,11 @@
           </div>
         </div>
 
+        <div class="error-banner" id="error-banner" hidden>
+          <span id="error-message"></span>
+          <button class="error-retry" id="error-retry" type="button">retry</button>
+        </div>
+
         <div class="filters">
           <div id="range-pills" class="pills">
             <span class="pill" data-days="1">1d</span>
@@ -58,7 +63,7 @@
           <div class="gauge" id="gauge-moisture">
             <div class="gauge-ring" id="gauge-moisture-ring">
               <div class="gauge-inner">
-                <span class="gauge-value" id="moisture">&ndash;<span class="gauge-unit">%</span></span>
+                <span class="gauge-value skeleton" id="moisture">&ndash;<span class="gauge-unit">%</span></span>
                 <span class="gauge-label">moisture</span>
               </div>
             </div>
@@ -66,7 +71,7 @@
           <div class="gauge" id="gauge-battery">
             <div class="gauge-ring" id="gauge-battery-ring">
               <div class="gauge-inner">
-                <span class="gauge-value" id="battery-percent">&ndash;<span class="gauge-unit">%</span></span>
+                <span class="gauge-value skeleton" id="battery-percent">&ndash;<span class="gauge-unit">%</span></span>
                 <span class="gauge-label">battery</span>
               </div>
             </div>
@@ -74,7 +79,7 @@
           <div class="gauge" id="gauge-temp">
             <div class="gauge-ring" id="gauge-temp-ring">
               <div class="gauge-inner">
-                <span class="gauge-value" id="temperature">&ndash;<span class="gauge-unit">&deg;</span></span>
+                <span class="gauge-value skeleton" id="temperature">&ndash;<span class="gauge-unit">&deg;</span></span>
                 <span class="gauge-label">temp</span>
               </div>
             </div>
@@ -84,35 +89,44 @@
         <div class="info-row">
           <div class="info-box">
             <div class="info-label">last update</div>
-            <div class="info-value" id="last-updated-time">&ndash;</div>
+            <div class="info-value skeleton" id="last-updated-time">&ndash;</div>
+            <div class="info-relative" id="last-updated-relative"></div>
           </div>
           <div class="info-box">
             <div class="info-label">last watered</div>
-            <div class="info-value" id="last-watered-time">&ndash;</div>
+            <div class="info-value skeleton" id="last-watered-time">&ndash;</div>
+            <div class="info-relative" id="last-watered-relative"></div>
           </div>
           <div class="info-box">
             <div class="info-label">next watering</div>
-            <div class="info-value" id="next-watering-time">&ndash;</div>
+            <div class="info-value skeleton" id="next-watering-time">&ndash;</div>
           </div>
         </div>
 
-        <div class="chart-header">
-          <span class="chart-title">water: <span class="water-status-word" id="water-status-word">&ndash;</span></span>
-          <span class="chart-max-temp"><span class="chart-max-temp-label">MAX</span> <span id="max-temperature">&ndash;&deg;C</span></span>
-        </div>
-        <div id="chart"></div>
-        <div class="legend">
-          <span class="legend-item"><span class="legend-swatch legend-swatch--moisture"></span>moisture %</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--battery"></span>battery %</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--temp"></span>temp &deg;C</span>
+        <div class="chart-section" id="chart-section">
+          <div class="chart-header">
+            <span class="chart-title">water: <span class="water-status-word" id="water-status-word">&ndash;</span></span>
+            <span class="chart-max-temp"><span class="chart-max-temp-label">MAX</span> <span id="max-temperature">&ndash;&deg;C</span></span>
+          </div>
+          <div id="chart" class="skeleton"></div>
+          <div class="legend">
+            <span class="legend-item"><span class="legend-swatch legend-swatch--moisture"></span>moisture %</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--battery"></span>battery %</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--temp"></span>temp &deg;C</span>
+          </div>
+
+          <div class="chart-title chart-title--strip">watering &middot; water tank</div>
+          <div id="strip" class="skeleton"></div>
+          <div class="legend">
+            <span class="legend-item"><svg width="9" height="11" viewBox="0 0 32 36"><path d="M16 1 C16 1 29 15 29 22 A13 13 0 1 1 3 22 C3 15 16 1 16 1 Z" fill="#7fd4ff"></path></svg>watered</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--avail"></span>water available</span>
+            <span class="legend-item"><span class="legend-swatch legend-swatch--empty"></span>tank empty</span>
+          </div>
         </div>
 
-        <div class="chart-title chart-title--strip">watering &middot; water tank</div>
-        <div id="strip"></div>
-        <div class="legend">
-          <span class="legend-item"><svg width="9" height="11" viewBox="0 0 32 36"><path d="M16 1 C16 1 29 15 29 22 A13 13 0 1 1 3 22 C3 15 16 1 16 1 Z" fill="#7fd4ff"></path></svg>watered</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--avail"></span>water available</span>
-          <span class="legend-item"><span class="legend-swatch legend-swatch--empty"></span>tank empty</span>
+        <div class="empty-state" id="empty-state" hidden>
+          <svg width="34" height="34" viewBox="0 0 24 24"><path d="M12 2 C4 8 4 18 12 22 C20 18 20 8 12 2 Z" fill="#46603e"></path></svg>
+          <span>No data for this range yet.</span>
         </div>
 
       </div>

--- a/garden-bot/front-end/index.js
+++ b/garden-bot/front-end/index.js
@@ -63,9 +63,30 @@ function computeNextWatering(lastWateredMs, maxRecentTemperature) {
   return Math.min(...candidates);
 }
 
+const STORAGE_KEY = 'garden-bot-filters';
+
+function loadStoredFilters() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
+function saveStoredFilters() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ days: state.days, device: state.device }));
+  } catch (e) {
+    // ignore (e.g. storage disabled)
+  }
+}
+
+const stored = loadStoredFilters();
 const state = {
-  days: 3,
-  device: 'cherry-3-pot',
+  days: (stored && stored.days) || 3,
+  device: (stored && stored.device) || 'cherry-3-pot',
   deviceOpen: false
 };
 
@@ -302,7 +323,12 @@ function renderFilterUI() {
   document.getElementById('device-menu').hidden = !state.deviceOpen;
 }
 
+let fetchInFlight = false;
+
 function fetchAndRender() {
+  if (fetchInFlight) return;
+  fetchInFlight = true;
+  document.getElementById('live-badge').classList.add('status-refreshing');
   fetchDataJSON(state.days, state.device)
     .then(dataObj => {
       const points = toPoints(dataObj);
@@ -316,6 +342,10 @@ function fetchAndRender() {
     })
     .catch(error => {
       console.error('There was a problem with the fetch operation:', error);
+    })
+    .finally(() => {
+      fetchInFlight = false;
+      document.getElementById('live-badge').classList.remove('status-refreshing');
     });
 }
 
@@ -323,6 +353,7 @@ document.getElementById('range-pills').addEventListener('click', e => {
   const pill = e.target.closest('.pill');
   if (!pill) return;
   state.days = Number(pill.dataset.days);
+  saveStoredFilters();
   renderFilterUI();
   fetchAndRender();
 });
@@ -339,7 +370,12 @@ document.getElementById('device-menu').addEventListener('click', e => {
   e.stopPropagation();
   state.device = opt.dataset.device;
   state.deviceOpen = false;
+  saveStoredFilters();
   renderFilterUI();
+  fetchAndRender();
+});
+
+document.getElementById('live-badge').addEventListener('click', () => {
   fetchAndRender();
 });
 

--- a/garden-bot/front-end/index.js
+++ b/garden-bot/front-end/index.js
@@ -102,6 +102,17 @@ function fmt(ts) {
   return pad(x.getHours()) + ':' + pad(x.getMinutes()) + ' ' + pad(x.getDate()) + '.' + pad(x.getMonth() + 1);
 }
 
+function relativeTime(ts) {
+  const diffSec = Math.floor((Date.now() - ts) / 1000);
+  if (diffSec < 5) return 'just now';
+  if (diffSec < 60) return diffSec + 's ago';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return diffMin + 'm ago';
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return diffHour + 'h ago';
+  return Math.floor(diffHour / 24) + 'd ago';
+}
+
 function mapNumRange(num, inMin, inMax, outMin, outMax) {
   if (num < inMin) return outMin;
   if (num > inMax) return outMax;
@@ -191,6 +202,7 @@ function computeStats(points) {
     waterColor: last.water ? '#7fd49b' : '#e08a5e',
     lastUpdateMs: last.t,
     lastUpdate: fmt(last.t),
+    lastWateredMs,
     lastWatered: lastWateredMs ? fmt(lastWateredMs) : '—',
     nextWatering: lastWateredMs ? fmt(computeNextWatering(lastWateredMs, maxRecentTemp)) : '—',
     maxTemp,
@@ -202,12 +214,32 @@ function setGaugeRing(ringEl, pct, color) {
   ringEl.style.background = 'conic-gradient(' + color + ' ' + (pct * 3.6) + 'deg,rgba(168,198,134,.12) 0)';
 }
 
+function unskeleton(...elements) {
+  elements.forEach(el => el.classList.remove('skeleton'));
+}
+
+const relativeTimes = { lastUpdateMs: null, lastWateredMs: null };
+
+function renderRelativeTimes() {
+  document.getElementById('last-updated-relative').textContent =
+    relativeTimes.lastUpdateMs ? relativeTime(relativeTimes.lastUpdateMs) : '';
+  document.getElementById('last-watered-relative').textContent =
+    relativeTimes.lastWateredMs ? relativeTime(relativeTimes.lastWateredMs) : '';
+}
+
+setInterval(renderRelativeTimes, 15 * 1000);
+
 function renderStats(points) {
   const s = computeStats(points);
 
   document.getElementById('moisture').innerHTML = s.curMoisture + '<span class="gauge-unit">%</span>';
   document.getElementById('battery-percent').innerHTML = s.curBattery + '<span class="gauge-unit">%</span>';
   document.getElementById('temperature').innerHTML = s.curTemp + '<span class="gauge-unit">°</span>';
+  unskeleton(
+    document.getElementById('moisture'),
+    document.getElementById('battery-percent'),
+    document.getElementById('temperature')
+  );
 
   setGaugeRing(document.getElementById('gauge-moisture-ring'), s.curMoisture, THEME.moisture);
   setGaugeRing(document.getElementById('gauge-battery-ring'), s.curBattery, THEME.battery);
@@ -216,6 +248,15 @@ function renderStats(points) {
   document.getElementById('last-updated-time').textContent = s.lastUpdate;
   document.getElementById('last-watered-time').textContent = s.lastWatered;
   document.getElementById('next-watering-time').textContent = s.nextWatering;
+  unskeleton(
+    document.getElementById('last-updated-time'),
+    document.getElementById('last-watered-time'),
+    document.getElementById('next-watering-time')
+  );
+
+  relativeTimes.lastUpdateMs = s.lastUpdateMs;
+  relativeTimes.lastWateredMs = s.lastWateredMs;
+  renderRelativeTimes();
 
   const waterStatusWord = document.getElementById('water-status-word');
   waterStatusWord.textContent = s.waterLabel;
@@ -306,8 +347,11 @@ function buildStripOption(points) {
 }
 
 function renderCharts(points) {
-  if (!mainChart) mainChart = echarts.init(document.getElementById('chart'));
-  if (!stripChart) stripChart = echarts.init(document.getElementById('strip'));
+  const chartEl = document.getElementById('chart');
+  const stripEl = document.getElementById('strip');
+  unskeleton(chartEl, stripEl);
+  if (!mainChart) mainChart = echarts.init(chartEl);
+  if (!stripChart) stripChart = echarts.init(stripEl);
   mainChart.setOption(buildMainOption(points), true);
   stripChart.setOption(buildStripOption(points), true);
 }
@@ -324,6 +368,21 @@ function renderFilterUI() {
 }
 
 let fetchInFlight = false;
+let hasLoadedOnce = false;
+
+function showError(message) {
+  document.getElementById('error-message').textContent = message;
+  document.getElementById('error-banner').hidden = false;
+}
+
+function hideError() {
+  document.getElementById('error-banner').hidden = true;
+}
+
+function setEmptyState(isEmpty) {
+  document.getElementById('chart-section').hidden = isEmpty;
+  document.getElementById('empty-state').hidden = !isEmpty;
+}
 
 function fetchAndRender() {
   if (fetchInFlight) return;
@@ -332,16 +391,21 @@ function fetchAndRender() {
   fetchDataJSON(state.days, state.device)
     .then(dataObj => {
       const points = toPoints(dataObj);
+      hideError();
       if (!points.length) {
-        document.getElementById('chart').innerHTML = 'No data';
+        setEmptyState(true);
+        hasLoadedOnce = true;
         return;
       }
+      setEmptyState(false);
       renderStats(points);
       renderCharts(points);
       scheduleNextFetch(points[points.length - 1].t);
+      hasLoadedOnce = true;
     })
     .catch(error => {
       console.error('There was a problem with the fetch operation:', error);
+      showError(hasLoadedOnce ? "Couldn't refresh — showing last known data." : "Couldn't reach the garden bot.");
     })
     .finally(() => {
       fetchInFlight = false;
@@ -376,6 +440,10 @@ document.getElementById('device-menu').addEventListener('click', e => {
 });
 
 document.getElementById('live-badge').addEventListener('click', () => {
+  fetchAndRender();
+});
+
+document.getElementById('error-retry').addEventListener('click', () => {
   fetchAndRender();
 });
 

--- a/garden-bot/front-end/style.css
+++ b/garden-bot/front-end/style.css
@@ -3,6 +3,11 @@
   50% { opacity: .35; }
 }
 
+@keyframes shimmer {
+  0% { background-position: -135% 0; }
+  100% { background-position: 135% 0; }
+}
+
 @keyframes sway {
   0%, 100% { transform: rotate(16deg); }
   50% { transform: rotate(23deg); }
@@ -424,6 +429,92 @@ body {
   width: 12px;
   height: 9px;
   background: rgba(224, 138, 94, .55);
+}
+
+.skeleton {
+  position: relative;
+  color: transparent !important;
+  pointer-events: none;
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: linear-gradient(100deg, rgba(168, 198, 134, .05) 35%, rgba(168, 198, 134, .2) 50%, rgba(168, 198, 134, .05) 65%);
+  background-size: 250% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+
+.gauge-value.skeleton,
+.info-value.skeleton {
+  display: inline-block;
+  min-width: 2.4em;
+}
+
+#chart.skeleton,
+#strip.skeleton {
+  color: transparent;
+  background: linear-gradient(100deg, rgba(168, 198, 134, .05) 35%, rgba(168, 198, 134, .14) 50%, rgba(168, 198, 134, .05) 65%);
+  background-size: 250% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+  border-radius: 14px;
+}
+
+#chart.skeleton::after,
+#strip.skeleton::after {
+  content: none;
+}
+
+.info-relative {
+  font: 400 10px 'Space Mono', monospace;
+  color: #6fa182;
+  margin-top: 2px;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 13px;
+  margin-bottom: 14px;
+  border-radius: 13px;
+  background: rgba(224, 138, 94, .14);
+  box-shadow: inset 0 0 0 1px rgba(224, 138, 94, .28);
+  font: 400 11px 'Space Mono', monospace;
+  color: #f0b08a;
+}
+
+.error-banner[hidden] {
+  display: none;
+}
+
+.error-retry {
+  flex-shrink: 0;
+  border: 0;
+  padding: 4px 10px;
+  border-radius: 8px;
+  background: rgba(224, 138, 94, .22);
+  color: #fbd9c2;
+  font: 700 11px 'Space Mono', monospace;
+  cursor: pointer;
+}
+
+.error-retry:hover {
+  background: rgba(224, 138, 94, .34);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 38px 10px;
+  color: #7fb39a;
+  font: 400 12px 'Space Mono', monospace;
+  text-align: center;
 }
 
 .footnote {

--- a/garden-bot/front-end/style.css
+++ b/garden-bot/front-end/style.css
@@ -115,6 +115,22 @@ body {
   background: rgba(127, 212, 154, .13);
   font: 400 11px 'Space Mono', monospace;
   color: #9fe0b8;
+  cursor: pointer;
+  user-select: none;
+  transition: opacity .15s ease;
+}
+
+.live-badge:hover {
+  opacity: .8;
+}
+
+.live-badge.status-refreshing {
+  opacity: .55;
+  pointer-events: none;
+}
+
+.live-badge.status-refreshing .live-dot {
+  animation: gpulse .6s infinite;
 }
 
 .live-dot {


### PR DESCRIPTION
Filters are saved to localStorage and restored on load instead of always
defaulting to 3d/cherry-3-pot. Clicking the live badge now re-fetches data
on demand, with a dimmed/pulsing state while the request is in flight.